### PR TITLE
Fix typo in project.pbxproj

### DIFF
--- a/{{ cookiecutter.dir_name }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
+++ b/{{ cookiecutter.dir_name }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
@@ -154,7 +154,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				60796EE119190F4100A9926B /* {{ cookiecutter.forma_name }} */,
+				60796EE119190F4100A9926B /* {{ cookiecutter.formal_name }} */,
 			);
 		};
 /* End PBXProject section */


### PR DESCRIPTION
This typo causes the following error

> Unable to create file '{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj'
> Error message: 'dict object' has no attribute 'forma_name'

Using

> Python 2.7.10
> cookiecutter==1.4.0