### PR TITLE
Include fixes from master in 3.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,5 @@ PyBee <3's contributions!
 
 Please be aware, PyBee operates under a Code of Conduct. 
 
-See [CONTRIBUTING to PyBee](pybee.org/contributing) for details.
+See [CONTRIBUTING to PyBee](http://pybee.org/contributing) for details.
 

--- a/{{ cookiecutter.dir_name }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
+++ b/{{ cookiecutter.dir_name }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
@@ -154,7 +154,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				60796EE119190F4100A9926B /* {{ cookiecutter.forma_name }} */,
+				60796EE119190F4100A9926B /* {{ cookiecutter.formal_name }} */,
 			);
 		};
 /* End PBXProject section */


### PR DESCRIPTION
Briefcase checks out the appropriate version of this cookie cutter template based on python version (https://github.com/pybee/briefcase/blob/master/briefcase/app.py#L101) and it is currently failing on 3.4 without the fixes from master.